### PR TITLE
limit library search to impi if I_MPI_ROOT env var set

### DIFF
--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -1,6 +1,7 @@
 """variables used across API implementation"""
 import ctypes
 from ctypes.util import find_library
+import os
 
 import numba
 import numpy as np

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -48,7 +48,7 @@ def create_status_buffer(count=1):
     return np.empty(count * 5, dtype=np.intc)
 
 
-for name in ("mpi", "msmpi", "impi"):
+for name in ("impi",) if "I_MPI_ROOT" in os.environ else ("mpi", "msmpi", "impi"):
     LIB = find_library(name)
     if LIB is not None:
         break


### PR DESCRIPTION
should provide a workaround for an issue when multiple MPI installations are present, Intel MPI's mpiexec is used but numba-mpi picks non-Intel library (thanks Souradeep Pal for reporting the problem)