### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of conduct for the numba-mpi open-source project
+
+As [contributors and maintainers of this project](https://github.com/orgs/numba-mpi/people),
+and in the interest of fostering an open and welcoming community, we pledge to respect all
+people who contribute through reporting issues, posting feature requests, updating 
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of technical experience and regardless of any non-technical
+personal characteristic or identity trait (gender, religion, physicality, age, ethnicity,
+essentially **any**).
+
+Nurturing open and unemotional code reviews and community discussions, we aim at ensuring
+fruitful and enriching collaboration experience and maintaining quality engineering
+standards. This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Examples of unacceptable behavior by participants include:
+
+* Breaching project security (e.g., granting GitHub access rights without ensuring
+  collaborators' consent);
+* Breaching collaborators' privacy (e.g., publishing other's private information without
+  permission);
+* Force developments (e.g., merging or releasing against expressed collaborators' comments
+  against doing it);
+* Any form of harassing language of exclusion;
+* Other unethical or unprofessional conduct (if in doubt, ask!).
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, issues, and other contributions that are not aligned to this Code of Conduct,
+or to ban temporarily or permanently any contributor for other behaviors that they deem
+inappropriate, threatening, offensive, or harmful. By adopting this Code of Conduct, project
+maintainers commit themselves to fairly, consistently and collaboratively applying these
+principles to every aspect of managing this project. 
+
+Reporting actions that are violating the hereby Code of Conduct can be done publicly on the
+project GitHub space, or if needed, can be reported directly to any of the
+[project maintainers listed on GitHub](https://github.com/orgs/numba-mpi/people)
+(as of the time of writing: Sylwester Arabas, David Zwicker, Kacper Derlatka, et al.).
+Maintainers are obligated to maintain confidentiality with regard to the reporter of a
+privately reported incident.
+
+Please note that, as of time of writing, the entirety of the project team is engaged in the
+development purely on voluntary basis.
+
+--
+This Code of Conduct was inspired by [Numba Code of Conduct](https://github.com/numba/numba-governance/blob/accepted/code-of-conduct.md).


### PR DESCRIPTION
required by NumFocus to apply for affiliation (see #124), and in principle a good idea to have it. 