### PR TITLE
avoid segfault in wait/test[all] tests by zero-initializing requsts arrays + add mpiexec-np-3 runs to CI. Closes #121 

### DIFF
--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -88,6 +88,7 @@ jobs:
     needs: [pylint, precommit, pdoc, zenodo_json]
     strategy:
       matrix:
+        mpi-np: [2, 3]
         platform: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         mpi: [ 'mpich', 'openmpi', 'msmpi', 'intelmpi']
@@ -130,7 +131,7 @@ jobs:
       - run: pip install -e .[tests]
       - run: python -We -c "import mpi4py"
       - run: python -We -c "import numba_mpi"
-      - run: mpiexec -n 2 pytest --durations=10 -p no:unraisableexception -We
+      - run: mpiexec -n ${{ matrix.mpi-np }} pytest --durations=10 -p no:unraisableexception -We
 
   dist:
     runs-on: ubuntu-latest

--- a/numba_mpi/api/requests.py
+++ b/numba_mpi/api/requests.py
@@ -34,6 +34,9 @@ def wait(request):
     """Wrapper for MPI_Wait. Returns integer status code (0 == MPI_SUCCESS).
     Status is currently not handled. Requires 'request' parameter to be a
     c-style pointer to MPI_Request (such as returned by 'isend'/'irecv').
+
+    Uninitialized contents of 'request' (e.g., from numpy.empty()) may
+    cause invalid pointer dereference and segmentation faults.
     """
 
     status_buffer = create_status_buffer()
@@ -64,6 +67,9 @@ def waitall(requests):
     """Wrapper for MPI_Waitall. Returns integer status code (0 == MPI_SUCCESS).
     Status is currently not handled. Requires 'requests' parameter to be an
     array or tuple of MPI_Request objects.
+
+    Uninitialized contents of 'requests' (e.g., from numpy.empty()) may
+    cause invalid pointer dereference and segmentation faults.
     """
     if isinstance(requests, np.ndarray):
         return _waitall_array_impl(requests)
@@ -123,6 +129,9 @@ def waitany(requests):
     status; second - the index of request that was completed. Status is
     currently not handled. Requires 'requests' parameter to be an array
     or tuple of MPI_Request objects.
+
+    Uninitialized contents of 'requests' (e.g., from numpy.empty()) may
+    cause invalid pointer dereference and segmentation faults.
     """
 
     if isinstance(requests, np.ndarray):
@@ -167,6 +176,9 @@ def test(request):
     flag that indicates whether given request is completed. Status is currently
     not handled. Requires 'request' parameter to be a c-style pointer to
     MPI_Request (such as returned by 'isend'/'irecv').
+
+    Uninitialized contents of 'request' (e.g., from numpy.empty()) may
+    cause invalid pointer dereference and segmentation faults.
     """
 
     status_buffer = create_status_buffer()
@@ -203,6 +215,9 @@ def testall(requests):
     flag that indicates whether given request is completed. Status is currently
     not handled. Requires 'requests' parameter to be an array or tuple of
     MPI_Request objects.
+
+    Uninitialized contents of 'requests' (e.g., from numpy.empty()) may
+    cause invalid pointer dereference and segmentation faults.
     """
     if isinstance(requests, np.ndarray):
         return _testall_array_impl(requests)
@@ -269,6 +284,9 @@ def testany(requests):
     that indicates whether any of requests is completed, and index of request
     that is guaranteed to be completed. Requires 'requests' parameter to be an
     array or tuple of MPI_Request objects.
+
+    Uninitialized contents of 'requests' (e.g., from numpy.empty()) may
+    cause invalid pointer dereference and segmentation faults.
     """
 
     if isinstance(requests, np.ndarray):

--- a/tests/api/test_isend_irecv.py
+++ b/tests/api/test_isend_irecv.py
@@ -176,7 +176,7 @@ def test_isend_irecv_waitall(isnd, ircv, wall, data_type):
     dst1 = np.empty_like(src1)
     dst2 = np.empty_like(src2)
 
-    reqs = np.empty((2,), dtype=mpi.RequestType)
+    reqs = np.zeros((2,), dtype=mpi.RequestType)
     if mpi.rank() == 0:
         status, reqs[0:1] = isnd(src1, dest=1, tag=11)
         assert status == MPI_SUCCESS
@@ -245,7 +245,7 @@ def test_isend_irecv_waitall_exchange(isnd, ircv, wall):
     src = get_random_array((5,))
     dst = np.empty_like(src)
 
-    reqs = np.empty((2,), dtype=mpi.RequestType)
+    reqs = np.zeros((2,), dtype=mpi.RequestType)
     if mpi.rank() == 0:
         status, reqs[0:1] = isnd(src, dest=1, tag=11)
         assert status == MPI_SUCCESS
@@ -261,6 +261,24 @@ def test_isend_irecv_waitall_exchange(isnd, ircv, wall):
     wall(reqs)
 
     np.testing.assert_equal(dst, src)
+
+
+@pytest.mark.parametrize(
+    "fun",
+    (
+        jit_waitany.py_func,
+        jit_waitall.py_func,
+        jit_testany.py_func,
+        jit_testall.py_func,
+        jit_waitany,
+        jit_waitall,
+        jit_testany,
+        jit_testall,
+    ),
+)
+def test_wall_segfault(fun):
+    reqs = np.zeros((2,), dtype=mpi.RequestType)
+    fun(reqs)
 
 
 @pytest.mark.parametrize(
@@ -282,7 +300,7 @@ def test_isend_irecv_waitany(isnd, ircv, wany, wall, data_type):
     dst1 = np.empty_like(src1)
     dst2 = np.empty_like(src2)
 
-    reqs = np.empty((2,), dtype=mpi.RequestType)
+    reqs = np.zeros((2,), dtype=mpi.RequestType)
     if mpi.rank() == 0:
         status, reqs[0:1] = isnd(src1, dest=1, tag=11)
         assert status == MPI_SUCCESS
@@ -356,7 +374,7 @@ def test_isend_irecv_testall(isnd, ircv, tall, wall):
     dst1 = np.empty_like(src1)
     dst2 = np.empty_like(src2)
 
-    reqs = np.empty((2,), dtype=mpi.RequestType)
+    reqs = np.zeros((2,), dtype=mpi.RequestType)
     if mpi.rank() == 0:
         time.sleep(TEST_WAIT_FULL_IN_SECONDS)
 
@@ -402,7 +420,7 @@ def test_isend_irecv_testany(isnd, ircv, tany, wall):
     dst1 = np.empty_like(src1)
     dst2 = np.empty_like(src2)
 
-    reqs = np.empty((2,), dtype=mpi.RequestType)
+    reqs = np.zeros((2,), dtype=mpi.RequestType)
     if mpi.rank() == 0:
         time.sleep(TEST_WAIT_FULL_IN_SECONDS)
 


### PR DESCRIPTION
Co-authored-by: xann16