### PR TITLE
Disable PyPI uploads in Github Actions for forked repositories

### DIFF
--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -143,7 +143,6 @@ jobs:
       - run: mpiexec -n ${{ matrix.mpi-np }} pytest --durations=10 -p no:unraisableexception -We
 
   dist:
-    if: github.repository == 'numba-mpi/numba-mpi'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -173,13 +172,22 @@ jobs:
           cd /tmp  # make sure local files are not picked up
           python -We -c "import numba_mpi"
 
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - if: |-
+          ${{
+            github.repository == 'numba-mpi/numba-mpi' &&
+            github.event_name == 'push' &&
+            github.ref == 'refs/heads/main'
+          }}
         uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
           attestations: false
           repository_url: https://test.pypi.org/legacy/
 
-      - if: startsWith(github.ref, 'refs/tags')
+      - if: |-
+          ${{
+            github.repository == 'numba-mpi/numba-mpi' &&
+            startsWith(github.ref, 'refs/tags')
+          }}
         uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
           attestations: false

--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -143,6 +143,7 @@ jobs:
       - run: mpiexec -n ${{ matrix.mpi-np }} pytest --durations=10 -p no:unraisableexception -We
 
   dist:
+    if: github.repository == 'numba-mpi/numba-mpi'
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Small adjustment to CI settings to disable `dist` job except for "official" project repository (i.e. `numba-mpi/numba-mpi`), since in forked repositories it fails anyway due to lack of credentials and causes irritating false negative results (+ mail notifications), especially since weekly scheduled runs were added.

If it is incompatible with some workflows I am not aware of, @slayoo, please feel free to reject and close this PR.