### PR TITLE
Add macos-15 to CI workflows and change MPI not found error message to hint why lib not found

### DIFF
--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           mpi: ${{ matrix.mpi }}
       - if: matrix.platform == "macos-15"
-        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
+        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/usr/local/lib:/usr/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
       - if: matrix.mpi == 'intelmpi'
         run: |
           # checking if multiple MPI libs are OK

--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
-      - if: matrix.platform == "macos-15"
+      - if: ${{ matrix.platform == 'macos-15' }}
         run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
       - if: matrix.mpi == 'intelmpi'
         run: |

--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           mpi: ${{ matrix.mpi }}
       - if: matrix.platform == "macos-15"
-        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/usr/local/lib:/usr/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
+        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
       - if: matrix.mpi == 'intelmpi'
         run: |
           # checking if multiple MPI libs are OK

--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -107,6 +107,8 @@ jobs:
           mpi: msmpi
         - platform: macos-15
           mpi: intelmpi
+        - platform: macos-15
+          mpi: openmpi
         - platform: ubuntu-latest
           mpi: msmpi
         - platform: ubuntu-latest # TODO: #162

--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           mpi: ${{ matrix.mpi }}
       - if: ${{ matrix.platform == 'macos-15' }}
-        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
+        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/usr/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
       - if: matrix.mpi == 'intelmpi'
         run: |
           # checking if multiple MPI libs are OK

--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -132,6 +132,8 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
+      - if: matrix.platform == "macos-15"
+        run: echo DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
       - if: matrix.mpi == 'intelmpi'
         run: |
           # checking if multiple MPI libs are OK

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -65,11 +65,19 @@ if hasattr(ps, "memory_maps"):
                 if name + ("" if windows else ".") in path.stem:
                     LIB = str(path)
                     break
+
 else:
     for name in names:
         LIB = find_library(name)
         if LIB is not None:
             break
+
+if sys.platform == "darwin" and LIB is None:
+        LIB_bash_str = "$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+        LIB_bash = subprocess.run(f'echo {LIB_bash_str}', shell=True, stdout=subprocess.PIPE)
+        if LIB_bash.returncode == 0:
+            LIB = LIB_bash.stdout.decode('ascii').strip()+"/lib/libmpi.dylib"
+            
 
 if LIB is None:
     raise RuntimeError("no MPI library found")

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import os
+import subprocess
 import sys
 from ctypes.util import find_library
 from pathlib import Path
@@ -73,13 +74,25 @@ else:
             break
 
 if sys.platform == "darwin" and LIB is None:
-    brew_path = Path("/opt/homebrew/lib/libmpi.dylib")
+    brew_path_bash = subprocess.run(
+        r'echo "$(brew --prefix)/lib/libmpi.dylib"',
+        shell=True,
+        stdout=subprocess.PIPE,
+        check=False,
+    )
+    brew_path = Path(brew_path_bash.stdout.decode("ascii").strip())
     if brew_path.is_file():
         LIB = brew_path
     else:
-        port_path = Path("/opt/local/lib/openmpi-mp/libmpi.dylib")
-        LIB = port_path
-
+        port_path_bash = subprocess.run(
+            r'echo "$(port -q contents openmpi | grep -E libmpi.dylib)"',
+            shell=True,
+            stdout=subprocess.PIPE,
+            check=False,
+        )
+        port_path = Path(port_path_bash.stdout.decode("ascii").strip())
+        if port_path.is_file():
+            LIB = port_path
 if LIB is None:
     raise RuntimeError("no MPI library found")
 

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -1,8 +1,8 @@
 """variables used across API implementation"""
 
-import sys
 import ctypes
 import os
+import sys
 from ctypes.util import find_library
 from pathlib import Path
 

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -1,6 +1,5 @@
 """variables used across API implementation"""
 
-from pathlib import Path
 import sys
 import ctypes
 import os

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -1,9 +1,9 @@
 """variables used across API implementation"""
 
+from pathlib import Path
 import sys
 import ctypes
 import os
-import subprocess
 from ctypes.util import find_library
 from pathlib import Path
 
@@ -74,15 +74,12 @@ else:
             break
 
 if sys.platform == "darwin" and LIB is None:
-
-    homebrew_lib_bash_str = r"$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
-    homebrew_lib_bash = subprocess.run(
-         rf'echo "{homebrew_lib_bash_str}"', shell=True, stdout=subprocess.PIPE
-    )
-    if homebrew_lib_bash.returncode == 0:
-        LIB = homebrew_lib_bash.stdout.decode("ascii").strip() + "/lib/libmpi.dylib"
+    brew_path = Path("/opt/homebrew/lib/libmpi.dylib")
+    if brew_path.is_file():
+        LIB = brew_path
     else:
-        LIB = "/opt/local/lib/libmpi.dylib"
+        port_path = Path("/opt/local/lib/openmpi-mp/libmpi.dylib")
+        LIB = port_path
 
 if LIB is None:
     raise RuntimeError("no MPI library found")

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -76,7 +76,7 @@ if LIB is None:
     if sys.platform == "darwin":
         raise RuntimeError(
             """no MPI library found, if MPI was installed using Homebrew, the following might help:
-            export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH
+            export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/usr/lib:$DYLD_FALLBACK_LIBRARY_PATH
             """
         )
     raise RuntimeError("no MPI library found")

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -75,13 +75,13 @@ else:
 
 if sys.platform == "darwin" and LIB is None:
 
-    homebrew_lib_bash_str = "$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+    homebrew_lib_bash_str = r"$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
     homebrew_lib_bash = subprocess.run(
-         f"echo {homebrew_lib_bash_str}", shell=True, stdout=subprocess.PIPE
+         rf'echo "{homebrew_lib_bash_str}"', shell=True, stdout=subprocess.PIPE
     )
     if homebrew_lib_bash.returncode == 0:
         LIB = homebrew_lib_bash.stdout.decode("ascii").strip() + "/lib/libmpi.dylib"
-    elif:
+    else:
         LIB = "/opt/local/lib/libmpi.dylib"
 
 if LIB is None:

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -65,7 +65,6 @@ if hasattr(ps, "memory_maps"):
                 if name + ("" if windows else ".") in path.stem:
                     LIB = str(path)
                     break
-
 else:
     for name in names:
         LIB = find_library(name)
@@ -79,7 +78,6 @@ if sys.platform == "darwin" and LIB is None:
     )
     if LIB_bash.returncode == 0:
         LIB = LIB_bash.stdout.decode("ascii").strip() + "/lib/libmpi.dylib"
-
 
 if LIB is None:
     raise RuntimeError("no MPI library found")

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -1,7 +1,9 @@
 """variables used across API implementation"""
 
+import sys
 import ctypes
 import os
+import subprocess
 from ctypes.util import find_library
 from pathlib import Path
 

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -75,9 +75,9 @@ else:
 if LIB is None:
     if sys.platform == "darwin":
         raise RuntimeError(
-            """no MPI library found, please make sure that your
-            installation of MPI is found in
-            DYLD_FALLBACK_LIBRARY_PATH variable"""
+            """no MPI library found, if MPI was installed using Homebrew, the following might help:
+            export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH
+            """
         )
     raise RuntimeError("no MPI library found")
 

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -2,7 +2,6 @@
 
 import ctypes
 import os
-import subprocess
 import sys
 from ctypes.util import find_library
 from pathlib import Path
@@ -73,27 +72,12 @@ else:
         if LIB is not None:
             break
 
-if sys.platform == "darwin" and LIB is None:
-    brew_path_bash = subprocess.run(
-        r'echo "$(brew --prefix)/lib/libmpi.dylib"',
-        shell=True,
-        stdout=subprocess.PIPE,
-        check=False,
-    )
-    brew_path = Path(brew_path_bash.stdout.decode("ascii").strip())
-    if brew_path.is_file():
-        LIB = brew_path
-    else:
-        port_path_bash = subprocess.run(
-            r'echo "$(port -q contents openmpi | grep -E libmpi.dylib)"',
-            shell=True,
-            stdout=subprocess.PIPE,
-            check=False,
-        )
-        port_path = Path(port_path_bash.stdout.decode("ascii").strip())
-        if port_path.is_file():
-            LIB = port_path
 if LIB is None:
+    if sys.platform == "darwin":
+        raise RuntimeError(
+            """no MPI library found, please make sure that your
+            installation of MPI is found in the PATH variable"""
+        )
     raise RuntimeError("no MPI library found")
 
 libmpi = ctypes.CDLL(LIB)

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -73,11 +73,13 @@ else:
             break
 
 if sys.platform == "darwin" and LIB is None:
-        LIB_bash_str = "$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
-        LIB_bash = subprocess.run(f'echo {LIB_bash_str}', shell=True, stdout=subprocess.PIPE)
-        if LIB_bash.returncode == 0:
-            LIB = LIB_bash.stdout.decode('ascii').strip()+"/lib/libmpi.dylib"
-            
+    LIB_bash_str = "$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+    LIB_bash = subprocess.run(
+        f"echo {LIB_bash_str}", shell=True, stdout=subprocess.PIPE
+    )
+    if LIB_bash.returncode == 0:
+        LIB = LIB_bash.stdout.decode("ascii").strip() + "/lib/libmpi.dylib"
+
 
 if LIB is None:
     raise RuntimeError("no MPI library found")

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -76,7 +76,8 @@ if LIB is None:
     if sys.platform == "darwin":
         raise RuntimeError(
             """no MPI library found, please make sure that your
-            installation of MPI is found in the PATH variable"""
+            installation of MPI is found in
+            DYLD_FALLBACK_LIBRARY_PATH variable"""
         )
     raise RuntimeError("no MPI library found")
 

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -74,12 +74,15 @@ else:
             break
 
 if sys.platform == "darwin" and LIB is None:
-    LIB_bash_str = "$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
-    LIB_bash = subprocess.run(
-        f"echo {LIB_bash_str}", shell=True, stdout=subprocess.PIPE
+
+    homebrew_lib_bash_str = "$(brew --cellar open-mpi)/$(brew list --versions open-mpi | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+    homebrew_lib_bash = subprocess.run(
+         f"echo {homebrew_lib_bash_str}", shell=True, stdout=subprocess.PIPE
     )
-    if LIB_bash.returncode == 0:
-        LIB = LIB_bash.stdout.decode("ascii").strip() + "/lib/libmpi.dylib"
+    if homebrew_lib_bash.returncode == 0:
+        LIB = homebrew_lib_bash.stdout.decode("ascii").strip() + "/lib/libmpi.dylib"
+    elif:
+        LIB = "/opt/local/lib/libmpi.dylib"
 
 if LIB is None:
     raise RuntimeError("no MPI library found")

--- a/numba_mpi/common.py
+++ b/numba_mpi/common.py
@@ -75,8 +75,8 @@ else:
 if LIB is None:
     if sys.platform == "darwin":
         raise RuntimeError(
-            """no MPI library found, if MPI was installed using Homebrew, the following might help:
-            export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/usr/lib:$DYLD_FALLBACK_LIBRARY_PATH
+            """MPI library not found, if MPI was installed with Homebrew, export the following:
+            DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/usr/lib:$DYLD_FALLBACK_LIBRARY_PATH
             """
         )
     raise RuntimeError("no MPI library found")


### PR DESCRIPTION
Due to `ctypes.utils.find_library()` not working properly with newer macos versions I propose to add code section that is able to determine the path to `libmpi.dylib` if `open-mpi` is installed on the machine as seen in `common.py`.