### PR TITLE
Readme cleanup after issue #164 being fixed

### DIFF
--- a/.github/workflows/tests+pypi.yml
+++ b/.github/workflows/tests+pypi.yml
@@ -107,7 +107,7 @@ jobs:
           mpi: msmpi
         - platform: macos-15
           mpi: intelmpi
-        - platform: macos-15
+        - platform: macos-15   # TODO: # 163
           mpi: openmpi
         - platform: ubuntu-latest
           mpi: msmpi

--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ if numba_mpi.rank() == 0:
 
 - tests on Ubuntu 2024.4 that use MPICH are not run due to failures caused by newer version of MPICH (`4.2.0`); note, that previous tests ran
 using version `4.0.2` of MPICH (that is installed by default on Ubuntu 2022.4 using `apt`) were passing (see [related issue](https://github.com/numba-mpi/numba-mpi/issues/162) - TODO #162),
-- tests on Intel MacOS (v13) that use OpenMPI are currently not run due to failures being under investigation (see [related issue](https://github.com/numba-mpi/numba-mpi/issues/163)  - TODO #163),
-- `numba-mpi` currently does not support ARM-based MacOS, due to required code improvement (see [related issue](https://github.com/numba-mpi/numba-mpi/issues/164) - TODO #164).
+- tests on MacOS (both Intel- and ARM-based) that use OpenMPI are currently not run due to failures being under investigation (see [related issue](https://github.com/numba-mpi/numba-mpi/issues/163)  - TODO #163).
 
 ### MPI resources on the web:
 


### PR DESCRIPTION
Just minor sync of what is `README.md` and current state of excluded CI workflows.

@slayoo Sadly, I did not have an opportunity to do so during code review. In general, I think it would be a good suggestion/guideline for contributors to request review from creator of issue they are addressing, to be able to catch the need for such small adjustment earlier and do not proliferate such small PRs.